### PR TITLE
Expose API not using getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ given to your React component, _or_ to other calculated values (see: `sumSquared
 
 **Be careful to not cause an infinite dependency loop!**
 
+### Internet Explorer 8 support
+
+As this library utilizes Getters, which are not shimmable in IE8 and older, an alternate `noGettes` module is exposed.
+This version allows you to cache values, but are not able to inject other values such as `sumSquared`. Usage:
+
+```javascript
+import LazyCache from 'react-lazy-cache/noGetters';
+
+const cache = new LazyCache(...) // same signature as normal version
+
+const sum = cache.get('sum');
+```
+
+The difference is that it's a class and not a plain function (so you have to `new` it), and properties are accessed
+through the `get`-function, instead of as a property.
+
+
 ## Conclusion
 
 That's all you need to know! Go forth and intelligently cache your calculated values!

--- a/noGetters.js
+++ b/noGetters.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/noGetters');

--- a/src/noGetters.js
+++ b/src/noGetters.js
@@ -1,0 +1,59 @@
+import deepEqual from 'deep-equal';
+
+function intersects(array1, array2) {
+  return !!(array1 && array2 && array1.some(item => ~array2.indexOf(item)));
+}
+
+export default class LazyCache {
+  constructor(component, calculators) {
+    this.component = component;
+    this.allProps = [];
+    this.cache = Object.keys(calculators).reduce((accumulator, key) => {
+      const calculator = calculators[key];
+      const fn = calculator.fn;
+      const paramNames = calculator.params;
+      paramNames.forEach(param => {
+        if (!~this.allProps.indexOf(param)) {
+          this.allProps.push(param);
+        }
+      });
+      return {
+        ...accumulator,
+        [key]: {
+          value: undefined,
+          props: paramNames,
+          fn: fn
+        }
+      };
+    }, {});
+  }
+
+  get(key) {
+    const {component} = this;
+    const {value, fn, props} = this.cache[key];
+    if (value !== undefined) {
+      return value;
+    }
+    const params = props.map(prop => component.props[prop]);
+    const result = fn(...params);
+    this.cache[key].value = result;
+    return result;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {component} = this;
+    const diffProps = [];
+    this.allProps.forEach(prop => {
+      if (!deepEqual(component.props[prop], nextProps[prop])) {
+        diffProps.push(prop);
+      }
+    });
+    if (diffProps.length) {
+      Object.keys(this.cache).forEach(key => {
+        if (intersects(diffProps, this.cache[key].props)) {
+          delete this.cache[key].value; // uncache value
+        }
+      });
+    }
+  }
+}

--- a/test/noGetters.spec.js
+++ b/test/noGetters.spec.js
@@ -1,0 +1,238 @@
+import expect from 'expect';
+import NoGetters from '../src/noGetters';
+
+describe('lazyCache', () => {
+  it('should call on get', () => {
+    let calls = 0;
+    const instance = new NoGetters({
+      props: {
+        a: 4,
+        b: 5
+      }
+    }, {
+      calc: {
+        params: ['a', 'b'],
+        fn: (a, b) => {
+          calls++;
+          return a + b;
+        }
+      }
+    });
+
+    expect(calls).toBe(0);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+  });
+
+  it('should reset on prop change', () => {
+    let calls = 0;
+    const instance = new NoGetters({
+      props: {
+        a: 4,
+        b: 5
+      }
+    }, {
+      calc: {
+        params: ['a', 'b'],
+        fn: (a, b) => {
+          calls++;
+          return a + b;
+        }
+      }
+    });
+
+    expect(calls).toBe(0);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    instance.componentWillReceiveProps({a: 3, b: 5});
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(2);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(2);
+  });
+
+  it('should not reset on prop not changed', () => {
+    let calls = 0;
+    const instance = new NoGetters({
+      props: {
+        a: 4,
+        b: 5
+      }
+    }, {
+      calc: {
+        params: ['a', 'b'],
+        fn: (a, b) => {
+          calls++;
+          return a + b;
+        }
+      }
+    });
+
+    expect(calls).toBe(0);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    instance.componentWillReceiveProps({a: 4, b: 5});
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+  });
+
+  it('should not reset on unrelated prop change', () => {
+    let calls = 0;
+    const instance = new NoGetters({
+      props: {
+        a: 4,
+        b: 5,
+        c: 6
+      }
+    }, {
+      calc: {
+        params: ['a', 'b'],
+        fn: (a, b) => {
+          calls++;
+          return a + b;
+        }
+      }
+    });
+
+    expect(calls).toBe(0);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    instance.componentWillReceiveProps({a: 4, b: 5, c: 7});
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+    expect(instance.get('calc')).toBe(9);
+    expect(calls).toBe(1);
+  });
+
+  it.skip('should inject another calculated prop', () => {
+    let sumCalls = 0;
+    let productCalls = 0;
+    const instance = new NoGetters({
+      props: {
+        a: 4,
+        b: 5,
+        c: 6
+      }
+    }, {
+      sum: {
+        params: ['a', 'b'],
+        fn: (a, b) => {
+          sumCalls++;
+          return a + b;
+        }
+      },
+      product: {
+        params: ['sum', 'c'],
+        fn: (sum, c) => {
+          productCalls++;
+          return sum * c;
+        }
+      }
+    });
+
+    expect(sumCalls).toBe(0);
+    expect(productCalls).toBe(0);
+    expect(instance.get('product')).toBe(54);
+    expect(sumCalls).toBe(1);
+    expect(productCalls).toBe(1);
+    expect(instance.get('sum')).toBe(9);
+    expect(sumCalls).toBe(1);
+    expect(instance.get('product')).toBe(54);
+    expect(sumCalls).toBe(1);
+    expect(productCalls).toBe(1);
+  });
+
+  it.skip('should uncache value, but not calculated prop dep when only prop changes', () => {
+    let sumCalls = 0;
+    let productCalls = 0;
+    const props = {
+      a: 4,
+      b: 5,
+      c: 6
+    };
+    const instance = new NoGetters({props}, {
+      sum: {
+        params: ['a', 'b'],
+        fn: (a, b) => {
+          sumCalls++;
+          return a + b;
+        }
+      },
+      product: {
+        params: ['sum', 'c'],
+        fn: (sum, c) => {
+          productCalls++;
+          return sum * c;
+        }
+      }
+    });
+
+    expect(sumCalls).toBe(0);
+    expect(productCalls).toBe(0);
+    expect(instance.get('product')).toBe(54);
+    expect(sumCalls).toBe(1);
+    expect(productCalls).toBe(1);
+    expect(instance.get('sum')).toBe(9);
+    expect(sumCalls).toBe(1);
+    expect(instance.get('product')).toBe(54);
+    expect(sumCalls).toBe(1);
+    expect(productCalls).toBe(1);
+    instance.componentWillReceiveProps({a: 4, b: 5, c: 7});
+    props.c = 7;
+    expect(instance.get('product')).toBe(63);
+    expect(sumCalls).toBe(1);
+    expect(productCalls).toBe(2);
+  });
+
+  it.skip('should uncache calculated prop dep when its dependent is uncached', () => {
+    let sumCalls = 0;
+    let productCalls = 0;
+    const props = {
+      a: 4,
+      b: 5,
+      c: 6
+    };
+    const instance = new NoGetters({props}, {
+      sum: {
+        params: ['a', 'b'],
+        fn: (a, b) => {
+          sumCalls++;
+          return a + b;
+        }
+      },
+      product: {
+        params: ['sum', 'c'],
+        fn: (sum, c) => {
+          productCalls++;
+          return sum * c;
+        }
+      }
+    });
+
+    expect(sumCalls).toBe(0);
+    expect(productCalls).toBe(0);
+    expect(instance.get('product')).toBe(54);
+    expect(sumCalls).toBe(1);
+    expect(productCalls).toBe(1);
+    expect(instance.get('sum')).toBe(9);
+    expect(sumCalls).toBe(1);
+    expect(instance.get('product')).toBe(54);
+    expect(sumCalls).toBe(1);
+    expect(productCalls).toBe(1);
+    instance.componentWillReceiveProps({a: 5, b: 5, c: 6});
+    props.a = 5;
+    expect(instance.get('product')).toBe(60);
+    expect(sumCalls).toBe(2);
+    expect(productCalls).toBe(2);
+  });
+});


### PR DESCRIPTION
First try.

This is basically your initial commit (https://github.com/erikras/react-lazy-cache/commit/92fb80bb9f0593a3c9ee032c0c145aabb766eab0) with the dependency injection removed (https://github.com/erikras/react-lazy-cache/commit/5d17f2653922b79fafb8f08138f7fce460d71188) and inlined `intersects.js` which existed at the time.

All tests passed after the syntax change other than magical injection. I just skipped them instead of deleting them, but I don't think it's possible to support with the `get`-syntax, so might a well delete them, maybe?
